### PR TITLE
Change 'lamports' variables to double

### DIFF
--- a/src/main/java/org/p2p/solanaj/rpc/types/AccountInfo.java
+++ b/src/main/java/org/p2p/solanaj/rpc/types/AccountInfo.java
@@ -19,9 +19,9 @@ public class AccountInfo extends RpcResultObject {
         public Value(AbstractMap am) {
             this.data = (List) am.get("data");
             this.executable = (boolean) am.get("executable");
-            this.lamports = (long) (double) am.get("lamports");
+            this.lamports = (double) am.get("lamports");
             this.owner = (String) am.get("owner");
-            this.rentEpoch = (long) (double) am.get("rentEpoch");
+            this.rentEpoch = (double) am.get("rentEpoch");
         }
 
         @Json(name = "data")
@@ -31,7 +31,7 @@ public class AccountInfo extends RpcResultObject {
         private boolean executable;
 
         @Json(name = "lamports")
-        private long lamports;
+        private double lamports;
 
         @Json(name = "owner")
         private String owner;

--- a/src/main/java/org/p2p/solanaj/rpc/types/FeeRateGovernorInfo.java
+++ b/src/main/java/org/p2p/solanaj/rpc/types/FeeRateGovernorInfo.java
@@ -15,16 +15,16 @@ public class FeeRateGovernorInfo extends RpcResultObject
         private int burnPercent;
 
         @Json(name = "maxLamportsPerSignature")
-        private long maxLamportsPerSignature;
+        private double maxLamportsPerSignature;
 
         @Json(name = "minLamportsPerSignature")
-        private long minLamportsPerSignature;
+        private double minLamportsPerSignature;
 
         @Json(name = "targetLamportsPerSignature")
-        private long targetLamportsPerSignature;
+        private double targetLamportsPerSignature;
 
         @Json(name = "targetSignaturesPerSlot")
-        private long targetSignaturesPerSlot;
+        private double targetSignaturesPerSlot;
     }
 
     @Getter

--- a/src/main/java/org/p2p/solanaj/rpc/types/RecentBlockhash.java
+++ b/src/main/java/org/p2p/solanaj/rpc/types/RecentBlockhash.java
@@ -13,7 +13,7 @@ public class RecentBlockhash extends RpcResultObject {
     public static class FeeCalculator {
 
         @Json(name = "lamportsPerSignature")
-        private long lamportsPerSignature;
+        private double lamportsPerSignature;
     }
 
     @Getter

--- a/src/main/java/org/p2p/solanaj/rpc/types/Reward.java
+++ b/src/main/java/org/p2p/solanaj/rpc/types/Reward.java
@@ -12,7 +12,7 @@ public class Reward {
     private String pubkey;
 
     @Json(name = "lamports")
-    private int lamports;
+    private double lamports;
 
     @Json(name = "postBalance")
     private String postBalance;

--- a/src/main/java/org/p2p/solanaj/rpc/types/TokenResultObjects.java
+++ b/src/main/java/org/p2p/solanaj/rpc/types/TokenResultObjects.java
@@ -106,7 +106,7 @@ public class TokenResultObjects {
         private boolean executable;
 
         @Json(name = "lamports")
-        private long lamports;
+        private double lamports;
 
         @Json(name = "owner")
         private String owner;

--- a/src/test/java/org/p2p/solanaj/core/MainnetTest.java
+++ b/src/test/java/org/p2p/solanaj/core/MainnetTest.java
@@ -778,7 +778,8 @@ public class MainnetTest extends AccountBasedTest {
         PublicKey testMarket = new PublicKey("52fF6wBZdSL8niV2tGuPu5gap15qLu6vMbmDoPVEDRqL");
 
         try {
-            client.getApi().getAccountInfo(testMarket);
+            AccountInfo accountInfo = client.getApi().getAccountInfo(testMarket);
+            LOGGER.info(String.format("Account: %s", accountInfo.toString()));
         } catch (RpcException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
The 'lamports' variables in multiple classes were previously stored as long or int data types. Change these to double data type to prevent errors arising from large numbers. This is in accordance with the Solana RPC API specification which recommends 'lamports' to be handled as double. Also, minor addition to print out the 'AccountInfo' in the 'MainnetTest'.