### PR TITLE
Thank you, solanaj

### DIFF
--- a/src/main/java/org/p2p/solanaj/core/AccountMeta.java
+++ b/src/main/java/org/p2p/solanaj/core/AccountMeta.java
@@ -12,4 +12,16 @@ public class AccountMeta {
     private boolean isSigner;
 
     private boolean isWritable;
+
+    /**
+     * Sorting based on isSigner and isWritable cannot fully meet the requirements. This value can be used for custom sorting, because if the order is incorrect during serialization, it may lead to failed method calls.
+     */
+    private int sort = Integer.MAX_VALUE;
+
+    public AccountMeta(PublicKey publicKey, boolean isSigner, boolean isWritable) {
+        this.publicKey = publicKey;
+        this.isSigner = isSigner;
+        this.isWritable = isWritable;
+    }
+
 }

--- a/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
+++ b/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
@@ -1,26 +1,19 @@
 package org.p2p.solanaj.rpc;
 
-import java.util.*;
-import java.util.stream.Collectors;
 import org.p2p.solanaj.core.Account;
 import org.p2p.solanaj.core.PublicKey;
 import org.p2p.solanaj.core.Transaction;
 import org.p2p.solanaj.rpc.types.*;
-import org.p2p.solanaj.rpc.types.config.BlockConfig;
-import org.p2p.solanaj.rpc.types.config.LargestAccountConfig;
-import org.p2p.solanaj.rpc.types.config.LeaderScheduleConfig;
-import org.p2p.solanaj.rpc.types.config.ProgramAccountConfig;
-import org.p2p.solanaj.rpc.types.config.RpcEpochConfig;
 import org.p2p.solanaj.rpc.types.RpcResultTypes.ValueLong;
-import org.p2p.solanaj.rpc.types.config.RpcSendTransactionConfig;
+import org.p2p.solanaj.rpc.types.TokenResultObjects.TokenAccount;
+import org.p2p.solanaj.rpc.types.TokenResultObjects.TokenAmountInfo;
+import org.p2p.solanaj.rpc.types.config.*;
 import org.p2p.solanaj.rpc.types.config.RpcSendTransactionConfig.Encoding;
-import org.p2p.solanaj.rpc.types.config.SignatureStatusConfig;
-import org.p2p.solanaj.rpc.types.config.SimulateTransactionConfig;
-import org.p2p.solanaj.rpc.types.TokenResultObjects.*;
-import org.p2p.solanaj.rpc.types.config.Commitment;
-import org.p2p.solanaj.rpc.types.config.VoteAccountConfig;
 import org.p2p.solanaj.ws.SubscriptionWebSocketClient;
 import org.p2p.solanaj.ws.listeners.NotificationEventListener;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class RpcApi {
     private RpcClient client;
@@ -82,7 +75,7 @@ public class RpcApi {
                                   RpcSendTransactionConfig rpcSendTransactionConfig)
             throws RpcException {
         if (recentBlockHash == null) {
-            recentBlockHash = getRecentBlockhash();
+            recentBlockHash = getLatestBlockhash().getValue().getBlockhash();
         }
         transaction.setRecentBlockHash(recentBlockHash);
         transaction.sign(signers);


### PR DESCRIPTION
Hello, I have recently been using solanaj to integrate with a third-party contract, which has been very helpful. However, during the process of sending transactions, I found that `AccountMeta` is stored as a hash set within the `AccountKeysList`'s `accounts` collection, causing issues with signature verification in the third-party contract (which requires multiple accounts to sign). Therefore, I modified it to support custom order serialization into the `Message`.
Hello, I am currently developing logic on the testnet (using `TESTNET("api.testnet.solana.com")`). When sending transactions, using `getRecentBlockhash` results in a method not found error. After checking, I found that this method is deprecated. Therefore, I changed it to `getLatestBlockhash()` to send transactions successfully.