### PR TITLE
Token program - support for external fee payer

### DIFF
--- a/src/main/java/org/p2p/solanaj/core/AccountMeta.java
+++ b/src/main/java/org/p2p/solanaj/core/AccountMeta.java
@@ -13,15 +13,4 @@ public class AccountMeta {
 
     private boolean isWritable;
 
-    /**
-     * Sorting based on isSigner and isWritable cannot fully meet the requirements. This value can be used for custom sorting, because if the order is incorrect during serialization, it may lead to failed method calls.
-     */
-    private int sort = Integer.MAX_VALUE;
-
-    public AccountMeta(PublicKey publicKey, boolean isSigner, boolean isWritable) {
-        this.publicKey = publicKey;
-        this.isSigner = isSigner;
-        this.isWritable = isWritable;
-    }
-
 }

--- a/src/main/java/org/p2p/solanaj/core/Message.java
+++ b/src/main/java/org/p2p/solanaj/core/Message.java
@@ -147,26 +147,11 @@ public class Message {
         this.feePayer = feePayer;
     }
 
-    private List<AccountMeta> getAccountKeys() {
-        List<AccountMeta> keysList = accountKeys.getList();
-
-        // Check whether custom sorting is needed. The `getAccountKeys()` method returns a reversed list of accounts, with signable and mutable accounts at the end, but the fee is placed first. When a transaction involves multiple accounts that need signing, an incorrect order can cause bugs. Change to custom sorting based on the contract order.
-        boolean needSort = keysList.stream().anyMatch(accountMeta -> accountMeta.getSort() < Integer.MAX_VALUE);
-        if (needSort) {
-            // Sort in ascending order based on the `sort` field.
-            return keysList.stream()
-                    .sorted(Comparator.comparingInt(AccountMeta::getSort))
-                    .collect(Collectors.toList());
-        }
-
-        int feePayerIndex = findAccountIndex(keysList, feePayer.getPublicKey());
-        List<AccountMeta> newList = new ArrayList<AccountMeta>();
-        AccountMeta feePayerMeta = keysList.get(feePayerIndex);
-        newList.add(new AccountMeta(feePayerMeta.getPublicKey(), true, true));
-        keysList.remove(feePayerIndex);
-        newList.addAll(keysList);
-
-        return newList;
+    public List<AccountMeta> getAccountKeys() {
+        AccountKeysList accounts = new AccountKeysList();
+        accounts.add(new AccountMeta(feePayer.getPublicKey(), true, true));
+        accounts.addAll(accountKeys);
+        return accounts.getList();
     }
 
     private int findAccountIndex(List<AccountMeta> accountMetaList, PublicKey key) {

--- a/src/main/java/org/p2p/solanaj/programs/TokenProgram.java
+++ b/src/main/java/org/p2p/solanaj/programs/TokenProgram.java
@@ -70,18 +70,40 @@ public class TokenProgram extends Program {
      * @param destination The public key of the destination account
      * @param amount The amount of tokens to transfer
      * @param decimals The number of decimals in the token
-     * @param owner The public key of the source account owner
+     * @param owner The public key of the source account owner, also the fee payer
      * @param tokenMint The public key of the token's mint
      * @return A TransactionInstruction for the transfer
      */
     public static TransactionInstruction transferChecked(PublicKey source, PublicKey destination, long amount, byte decimals, PublicKey owner, PublicKey tokenMint) {
+        return transferChecked(source, destination, amount, decimals, owner, owner, tokenMint);
+    }
+
+
+    /**
+     * Creates a transaction instruction for a checked token transfer.
+     *
+     * @param source The public key of the source account
+     * @param destination The public key of the destination account
+     * @param amount The amount of tokens to transfer
+     * @param decimals The number of decimals in the token
+     * @param owner The public key of the source account owner
+     * @param fee The public key of the account paying fees
+     * @param tokenMint The public key of the token's mint
+     * @return A TransactionInstruction for the transfer
+     */
+    public static TransactionInstruction transferChecked(PublicKey source, PublicKey destination, long amount, byte decimals, PublicKey owner, PublicKey fee, PublicKey tokenMint) {
         final List<AccountMeta> keys = new ArrayList<>();
 
-        keys.add(new AccountMeta(source,false, true));
+        keys.add(new AccountMeta(source, false, true));
         // index 1 = token mint (https://docs.rs/spl-token/3.1.0/spl_token/instruction/enum.TokenInstruction.html#variant.TransferChecked)
         keys.add(new AccountMeta(tokenMint, false, false));
-        keys.add(new AccountMeta(destination,false, true));
-        keys.add(new AccountMeta(owner,true, false));
+        keys.add(new AccountMeta(destination, false, true));
+        if(owner == fee) {
+            keys.add(new AccountMeta(fee, true, true));
+        } else {
+            keys.add(new AccountMeta(owner, true, false));
+            keys.add(new AccountMeta(fee, true, true));
+        }
 
         byte[] transactionData = encodeTransferCheckedTokenInstructionData(
                 amount,


### PR DESCRIPTION
Allows to handle token transfers with fee payer different than source token account owner.
Scenario for that case is:
- transfer token to some fresh address
- try to spend it, without transfering SOL just to cover fees

Depends on #79 - account handling bugs caused message to be messed up completely during rendering.

Similar change should be implemented for other programs/methods.