### PR TITLE
Inspired by the transaction receipt synchronous blocking confirmation…

### DIFF
--- a/src/main/java/org/p2p/solanaj/transaction/confirm/SolanaPollingTransactionConfirmProcessor.java
+++ b/src/main/java/org/p2p/solanaj/transaction/confirm/SolanaPollingTransactionConfirmProcessor.java
@@ -1,0 +1,69 @@
+package org.p2p.solanaj.transaction.confirm;
+
+import org.p2p.solanaj.rpc.Cluster;
+import org.p2p.solanaj.rpc.RpcClient;
+import org.p2p.solanaj.rpc.RpcException;
+import org.p2p.solanaj.rpc.types.ConfirmedTransaction;
+import org.p2p.solanaj.rpc.types.config.Commitment;
+import org.p2p.solanaj.transaction.exceptions.SolanaTransactionException;
+
+
+/**
+ * 使用每个提供的事务id，轮询直到我们获到确认交易
+ */
+public class SolanaPollingTransactionConfirmProcessor extends SolanaTransactionConfirmProcessor {
+    protected final long sleepDuration;
+    protected final int attempts;
+
+    public SolanaPollingTransactionConfirmProcessor(RpcClient rpcClient, Commitment commitment, long sleepDuration, int attempts) {
+        super(rpcClient, commitment);
+        this.sleepDuration = sleepDuration;
+        this.attempts = attempts;
+    }
+
+    public SolanaPollingTransactionConfirmProcessor(RpcClient rpcClient, Commitment commitment) {
+        this(rpcClient, commitment, 1000, 120);
+    }
+
+    public SolanaPollingTransactionConfirmProcessor(RpcClient rpcClient) {
+        this(rpcClient, Commitment.FINALIZED);
+    }
+
+    public SolanaPollingTransactionConfirmProcessor() {
+        this(new RpcClient(Cluster.MAINNET));
+    }
+
+    @Override
+    public ConfirmedTransaction waitForTransactionConfirm(String txid) throws SolanaTransactionException, RpcException {
+        return getTransactionReceipt(txid, sleepDuration, attempts);
+    }
+
+    private ConfirmedTransaction getTransactionReceipt(
+            String txid, long sleepDuration, int attempts)
+            throws SolanaTransactionException, RpcException {
+
+        for (int i = 0; i < attempts; i++) {
+            ConfirmedTransaction confirmedTransaction = sendConfirmTransactionRequest(txid);
+
+            if (confirmedTransaction != null) {
+                return confirmedTransaction;
+            }
+
+            // Sleep unless it is the last attempt.
+            if (i < attempts - 1) {
+                try {
+                    Thread.sleep(sleepDuration);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        throw new SolanaTransactionException(
+                "Transaction confirm was not generated after "
+                        + ((sleepDuration * attempts) / 1000
+                        + " seconds for txid: "
+                        + txid),
+                txid);
+    }
+}

--- a/src/main/java/org/p2p/solanaj/transaction/confirm/SolanaTransactionConfirmProcessor.java
+++ b/src/main/java/org/p2p/solanaj/transaction/confirm/SolanaTransactionConfirmProcessor.java
@@ -1,0 +1,39 @@
+package org.p2p.solanaj.transaction.confirm;
+
+import org.p2p.solanaj.rpc.RpcClient;
+import org.p2p.solanaj.rpc.RpcException;
+import org.p2p.solanaj.rpc.types.ConfirmedTransaction;
+import org.p2p.solanaj.rpc.types.config.Commitment;
+import org.p2p.solanaj.transaction.exceptions.SolanaTransactionException;
+
+
+/**
+ * solana交易状态确认检查处理
+ */
+public abstract class SolanaTransactionConfirmProcessor {
+    private final RpcClient rpcClient;
+    private final Commitment commitment;
+
+    public SolanaTransactionConfirmProcessor(RpcClient rpcClient, Commitment commitment) {
+        this.rpcClient = rpcClient;
+        this.commitment = commitment;
+    }
+
+    public abstract ConfirmedTransaction waitForTransactionConfirm(String txid)
+            throws SolanaTransactionException, RpcException;
+
+    ConfirmedTransaction sendConfirmTransactionRequest(String txid)
+            throws RpcException, SolanaTransactionException {
+        ConfirmedTransaction confirmedTransaction = rpcClient.getApi().getTransaction(txid, commitment);
+
+        if (confirmedTransaction == null) {
+            return null;
+        }
+        if (confirmedTransaction.getMeta().getErr() != null) {
+            throw new SolanaTransactionException(
+                    "Error processing request: " + confirmedTransaction.getMeta().getErr());
+        }
+
+        return confirmedTransaction;
+    }
+}

--- a/src/main/java/org/p2p/solanaj/transaction/exceptions/SolanaTransactionException.java
+++ b/src/main/java/org/p2p/solanaj/transaction/exceptions/SolanaTransactionException.java
@@ -1,0 +1,27 @@
+package org.p2p.solanaj.transaction.exceptions;
+
+
+import lombok.Getter;
+
+import java.util.Optional;
+
+public class SolanaTransactionException extends Exception {
+
+    @Getter
+    private Optional<String> txid = Optional.empty();
+
+    public SolanaTransactionException(String message) {
+        super(message);
+    }
+
+    public SolanaTransactionException(String message, String txid) {
+        super(message);
+        this.txid = Optional.ofNullable(txid);
+    }
+
+    public SolanaTransactionException(Throwable cause) {
+        super(cause);
+    }
+
+
+}


### PR DESCRIPTION
Inspired by the transaction receipt synchronous blocking confirmation strategy in web3J, a synchronous blocking confirmation feature has been implemented in the current repository.