### PR TITLE
Added ability to use before/until params in getSignaturesForAddress

### DIFF
--- a/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
+++ b/src/main/java/org/p2p/solanaj/rpc/RpcApi.java
@@ -194,10 +194,15 @@ public class RpcApi {
 
     public List<SignatureInformation> getSignaturesForAddress(PublicKey account, int limit, Commitment commitment)
             throws RpcException {
+                return getSignaturesForAddress(account, limit, commitment, null, null)
+    }
+
+    public List<SignatureInformation> getSignaturesForAddress(PublicKey account, int limit, Commitment commitment, String before, String until)
+            throws RpcException {
         List<Object> params = new ArrayList<>();
 
         params.add(account.toString());
-        params.add(new ConfirmedSignFAddr2(limit, commitment));
+        params.add(new ConfirmedSignFAddr2(limit, commitment, before, until));
 
         List<AbstractMap> rawResult = client.call("getSignaturesForAddress", params, List.class);
 

--- a/src/main/java/org/p2p/solanaj/rpc/types/ConfirmedSignFAddr2.java
+++ b/src/main/java/org/p2p/solanaj/rpc/types/ConfirmedSignFAddr2.java
@@ -21,4 +21,11 @@ public class ConfirmedSignFAddr2 {
         this.limit = limit;
         this.commitment = commitment.getValue();
     }
+
+    public ConfirmedSignFAddr2(int limit, Commitment commitment, String before, String until) {
+        this.limit = limit;
+        this.commitment = commitment.getValue();
+        this.before = before;
+        this.until = until;
+    }
 }


### PR DESCRIPTION
Added before/until fields into constructor of ConfirmedSignFAddr2 to be able to use them in getSignaturesForAddress method.